### PR TITLE
Some performance tweaks

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -54,6 +54,7 @@ export default class App extends Component {
             </SyntaxHighlighter>
           </div>
           <DynamicBarChart
+            barGapSize={10}
             data={helpers.generateData(100, mocks.defaultChart, {
               prefix: "Iteration"
             })}

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,10 @@ function getRandomColor() {
   return color;
 };
 
+function translateY(value) {
+  return `translateY(${value}px)`;
+}
+
 function DynamicBarChart(props) {
   const [dataQueue, setDataQueue] = useState([]);
   const [activeItemIdx, setActiveItemIdx] = useState(0);
@@ -90,9 +94,10 @@ function DynamicBarChart(props) {
     };
   }, [activeItemIdx, afterClick]);
 
-  const { barHeight, baseline, iterationTimeout, chartWrapperStyles, mainWrapperStyles, iterationTitleStyles, labelStyles, baselineStyles, showTitle } = props;
+  const keys = Object.keys(currentValues);
+  const { barGapSize, barHeight, baseline, iterationTimeout, chartWrapperStyles, mainWrapperStyles, iterationTitleStyles, labelStyles, baselineStyles, showTitle } = props;
   const maxValue = highestValue / 0.85;
-  const sortedCurrentValues = Object.keys(currentValues).sort((a, b) => currentValues[b].value - currentValues[a].value);
+  const sortedCurrentValues = keys.sort((a, b) => currentValues[b].value - currentValues[a].value);
   const hasBaseline = baseline !== null && !isNaN(baseline);
   const currentItem = dataQueue[activeItemIdx - 1] || {};
 
@@ -109,7 +114,7 @@ function DynamicBarChart(props) {
               hasBaseline &&
               <div className="baseline" style={baselineStyles}><span>{baseline}</span></div>
             }
-            <div className={`chart-bars ${hasBaseline ? 'with-baseline' : ''}`} style={{ height: (barHeight + 20) * Object.keys(currentValues).length }}>
+            <div className={`chart-bars ${hasBaseline ? 'with-baseline' : ''}`} style={{ height: (barHeight + barGapSize) * keys.length }}>
               {
                 sortedCurrentValues.map((key, idx) => {
                   const currentValueData = currentValues[key];
@@ -132,7 +137,7 @@ function DynamicBarChart(props) {
                   }
 
                   return (
-                    <div className={`bar-wrapper ${behindbaseline ? 'behind-baseline' : ''}`} style={{ top: (barHeight + 20) * idx, transitionDuration: iterationTimeout / 1000 }} key={`bar_${key}`}>
+                    <div className={`bar-wrapper ${behindbaseline ? 'behind-baseline' : ''}`} style={{ transform: translateY((barHeight + barGapSize) * idx), transitionDuration: iterationTimeout / 1000 }} key={`bar_${key}`}>
                       <label style={labelStyles}>
                         {
                           !currentValueData.label
@@ -165,6 +170,7 @@ DynamicBarChart.propTypes = {
   data: PropTypes.array,
   startRunningTimeout: PropTypes.number,
   barHeight: PropTypes.number,
+  barGapSize: PropTypes.number,
   baseline: PropTypes.number,
   showStartButton: PropTypes.bool,
   startButtonText: PropTypes.string,
@@ -185,6 +191,7 @@ DynamicBarChart.defaultProps = {
   data: [],
   startRunningTimeout: 0,
   barHeight: 50,
+  barGapSize: 20,
   baseline: null,
   showStartButton: false,
   startButtonText: 'Start',

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -91,7 +91,8 @@
     position: absolute;
     top: 0;
     left: 0;
-    transition: top 0.5s linear;
+    transform: translateY(0);
+    transition: transform 0.5s linear;
     padding-left: 200px;
     box-sizing: border-box;
     width: 100%;


### PR DESCRIPTION
* Using `transform: translateY` transition instead of `top` transitions
* Added `barGapSize` prop to control the gap size between bars
* Calling to `Object.keys` only once per render